### PR TITLE
adding short descriptions, plus TagHelpers repo

### DIFF
--- a/Hacktoberfest2022/hacktoberfest-package-repos.md
+++ b/Hacktoberfest2022/hacktoberfest-package-repos.md
@@ -2,14 +2,15 @@
 
 ## Participating packages
 
-These packages are looking for contributions as part of this year's Hacktoberfest:
+These packages are looking for contributions as part of this year's Umbraco Hacktoberfest:
 
-- [BackOfficeThemes](https://github.com/KevinJump/Our.Umbraco.BackOfficeThemes)
-- [Contentment](https://github.com/leekelleher/umbraco-contentment/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
-- [MaintenanceMode](https://github.com/KevinJump/Our.Umbraco.MaintenanceMode)
-- [uSync](https://github.com/KevinJump/uSync/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- [Backoffice Themes](https://github.com/KevinJump/Our.Umbraco.BackOfficeThemes) - let's you pick your own colours for your Umbraco backoffice
+- [Contentment](https://github.com/leekelleher/umbraco-contentment/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) - a collection of powerful data editors to your Umbraco backoffice
+- [Maintenance Mode](https://github.com/KevinJump/Our.Umbraco.MaintenanceMode) - a dashboard to quickly switch your site on and off for visitors
+- [Our Umbraco TagHelpers](https://github.com/umbraco-community/Our-Umbraco-TagHelpers) - adds a collection of C# TagHelpers useful for Umbraco
+- [uSync](https://github.com/KevinJump/uSync/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) - stores Umbraco database items to disk so you can source control, copy and move between installations
 
 
 ## Want to see your package listed above?
 
-Submit a pull request to this page that adds the name of your package with a link to the filtered list of issues that you would like help with. Please add in alphabetical order.
+Submit a pull request to this page that adds the name of your package with a link to the filtered list of issues that you would like help with, and a one line description. Packages should be added in alphabetical order by name.


### PR DESCRIPTION
I think the packages repo list looks a bit more inspiring if it includes a short one-liner describing the package rather than just the names. So I've added descriptions for the existing items using the wording from their own package pages to see if you agree!

I've also added the TagHelpers community package as that repo is already flagged for 'hacktoberfest' with some open issues available